### PR TITLE
Add Vue 3 framework integration on README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Blaze Slider is framework agnostic - it can work with all frameworks, all it req
 Here are some prebuilt integrations:
 
 - React - [react-blaze-slider](https://github.com/blaze-slider/blaze-slider/tree/main/blaze-slider-react)
+- Vue 3 - [vue-blaze-slider](https://github.com/TotomInc/vue-blaze-slider)
 
 ## License
 


### PR DESCRIPTION
Thanks for your awesome library!

I've been working quickly on a Vue 3 framework integration for Blaze Slider.

Actually, the package is published on npm in a beta state but will be very soon stable.

It's actually usable in a Vue 3 project. We can add/disable pagination and pass `BlazeConfig` as an `:options` prop.