### PR TITLE
Make dragSupport eventListerner passive.

### DIFF
--- a/blaze-slider/src/utils/drag.ts
+++ b/blaze-slider/src/utils/drag.ts
@@ -87,7 +87,7 @@ export function dragSupport(slider: BlazeSlider) {
   const event = isTouch() ? 'touchstart' : 'pointerdown'
 
   // @ts-expect-error
-  track.addEventListener(event, handlePointerDown)
+  track.addEventListener(event, handlePointerDown, { passive: true })
 }
 
 function updateEventListener(


### PR DESCRIPTION
Not essential, but good hygiene to make scroll/touch event listeners like the one in `dragSupport()` passive.