### PR TITLE
Fix: trigger onSlide at the beginning of slide

### DIFF
--- a/blaze-slider/src/utils/methods.ts
+++ b/blaze-slider/src/utils/methods.ts
@@ -1,11 +1,11 @@
 import { BlazeSlider } from '../slider'
-import { onSlideEnd } from './scroll'
+import { triggerOnSlide } from './scroll'
 
 // when loop is disabled, we must update the offset
 export function noLoopScroll(slider: BlazeSlider) {
   slider.offset = -1 * slider.states[slider.stateIndex].page[0]
   updateTransform(slider)
-  onSlideEnd(slider)
+  triggerOnSlide(slider)
 }
 
 export function wrapPrev(slider: BlazeSlider, count: number) {

--- a/blaze-slider/src/utils/scroll.ts
+++ b/blaze-slider/src/utils/scroll.ts
@@ -61,6 +61,7 @@ export function scrollNext(slider: BlazeSlider, slideCount: number) {
     slider.offset = -1 * slideCount
     updateTransform(slider)
 
+    triggerOnSlide(slider)
     // once the transition is done
     setTimeout(() => {
       // remove the elements from start that are no longer visible and put them at the end
@@ -75,7 +76,6 @@ export function scrollNext(slider: BlazeSlider, slideCount: number) {
       rAf(() => {
         rAf(() => {
           enableTransition(slider)
-          triggerOnSlide(slider)
         })
       })
     }, slider.config.transitionDuration)

--- a/blaze-slider/src/utils/scroll.ts
+++ b/blaze-slider/src/utils/scroll.ts
@@ -31,7 +31,7 @@ export function scrollPrev(slider: BlazeSlider, slideCount: number) {
         rAf(() => {
           slider.offset = 0
           updateTransform(slider)
-          onSlideEnd(slider)
+          triggerOnSlide(slider)
         })
       })
     }
@@ -75,19 +75,19 @@ export function scrollNext(slider: BlazeSlider, slideCount: number) {
       rAf(() => {
         rAf(() => {
           enableTransition(slider)
-          onSlideEnd(slider)
+          triggerOnSlide(slider)
         })
       })
     }, slider.config.transitionDuration)
   }
 }
 
-export function onSlideEnd(slider: BlazeSlider) {
+export function triggerOnSlide(slider: BlazeSlider) {
   if (slider.onSlideCbs) {
     const state = slider.states[slider.stateIndex]
     const [firstSlideIndex, lastSlideIndex] = state.page
     slider.onSlideCbs.forEach((cb) =>
-      cb(slider.stateIndex, firstSlideIndex, lastSlideIndex)
+      cb(slider.stateIndex, firstSlideIndex, lastSlideIndex),
     )
   }
 }


### PR DESCRIPTION
Addressing: #71 
- rename `onSlideEnd` to `triggerSlideEnd` as it basically only do that
- in `scrollNext`, call `triggerSlideEnd` before `isTransitioning` timeout

It fixed my issue, I didn't try with config.loop set to false though.