### PR TITLE
Fix jump when releasing backward drag in loop mode

### DIFF
--- a/blaze-slider/src/utils/drag.ts
+++ b/blaze-slider/src/utils/drag.ts
@@ -61,17 +61,22 @@ function handlePointerMove(this: Track, moveEvent: PointerEvent | TouchEvent) {
 }
 
 function handlePointerUp(this: Track) {
-  const track = this
-  const dragged = track.slider.dragged
-  track.slider.isDragging = false
+    const track = this;
+    const slider = track.slider;
+    const dragged = slider.dragged;
 
-  updateEventListener(track, 'removeEventListener')
+    slider.isDragging = false;
+    updateEventListener(track, 'removeEventListener');
 
-  // reset drag
-  track.slider.dragged = 0
-  updateTransform(track.slider)
+    if (track.isScrolled && slider.config.loop) {
+        track.slider.dragged = 0;
+        return;
+    }
 
-  enableTransition(track.slider)
+    enableTransition(slider);
+
+    slider.dragged = 0;
+    updateTransform(slider);
 
   if (!track.isScrolled) {
     if (dragged < -1 * slideThreshold) {


### PR DESCRIPTION
### Fix jump when releasing backward drag (loop mode)
**Problem**
When dragging backwards (prev) in loop mode, the slider briefly jumps in the opposite direction on pointer/touch release in Firefox and Safari.

This happens because:
- prev() is triggered during pointermove
- handlePointerUp() then performs an additional transform reset
- this results in a one-frame intermediate transform that appears as a “kick back”

Chrome tends to coalesce this frame, but Firefox/Safari render it visibly.

**Solution**

Prevent double settle on backward drag:
- If prev() was already triggered during drag (isScrolled && loop), handlePointerUp() now skips resetting the transform.
- In this case, the settling logic already attached by scrollPrev() remains the single source of truth.

This avoids applying two conflicting transform updates on pointer release.

**Result**
- No jump on backward drag release
- Forward and backward drag behavior is consistent
- Firefox and Safari no longer show the visual “kick back”
- No behavior change for non-loop or forward drag cases

Tested

- Chrome (desktop/mobile)
- Firefox (desktop/mobile)
- Safari (desktop/mobile)